### PR TITLE
fix(FileLinkReplaceExtension) Re-wrote file link logic

### DIFF
--- a/src/Model/WYSIWYGElement.php
+++ b/src/Model/WYSIWYGElement.php
@@ -15,19 +15,16 @@ class WYSIWYGElement extends ViewableData
     protected $linkHTML = "";
 
     /**
-     * @var int|null
+     * @var File|null
      */
-    protected $fileId = null;
+    protected $file = null;
 
     /**
      * @return File|null
      */
     public function getFile()
     {
-        $id = $this->getFileId();
-        return $id ?
-        File::get()->filter('ID', $id)->first() :
-        null;
+        return $this->file;
     }
 
     /**
@@ -47,14 +44,14 @@ class WYSIWYGElement extends ViewableData
         return $this->linkHTML;
     }
 
-    public function setFileId(int $id)
+    public function setFile(File $file)
     {
-        $this->fileId = $id;
+        $this->file = $file;
         return $this;
     }
 
     public function getFileId()
     {
-        return $this->fileId;
+        return $this->file->ID;
     }
 }

--- a/tests/FileLinkReplaceExtensionTest.php
+++ b/tests/FileLinkReplaceExtensionTest.php
@@ -51,7 +51,7 @@ class FileLinkReplaceExtensionTest extends FunctionalTest
     {
 
         $testFile = $this->objFromFixture(File::class, 'example_file');
-        
+
         $parser = new ShortcodeParser();
         $parser->register('file_link', [FileShortcodeProvider::class, 'handle_shortcode']);
 
@@ -60,8 +60,8 @@ class FileLinkReplaceExtensionTest extends FunctionalTest
 
         $element = WYSIWYGElement::create();
         $linkHtml = '<a href="/assets/FileLinkReplaceExtensionTest/55b443b601/example.pdf" class="file" data-type="pdf" data-size="977 KB">Example Content</a>';
-        
-        $element->setFileId($testFile->ID);
+
+        $element->setFile($testFile);
         $element->setLinkHTML($linkHtml);
         $htmlExpected = $element
             ->renderWith(
@@ -84,7 +84,7 @@ class FileLinkReplaceExtensionTest extends FunctionalTest
         );
 
         $testFile->delete();
-    
+
         $this->assertEquals('', $parser->parse('[file_link]'), 'Test that invalid ID attributes are not parsed.');
         $this->assertEquals('', $parser->parse('[file_link,id="text"]'));
         $this->assertEquals('', $parser->parse('[file_link,id="-1"]'), 'Short code is removed if file record is not present.');


### PR DESCRIPTION
Previous implementation wouldn't handle having non-file links as the first
ones appearing on the page. Instead, the files are looked up by the links
present in content to ensure a like-for-like match